### PR TITLE
dts: ls1021atsn: enable driver for SDHC controller

### DIFF
--- a/arch/arm/boot/dts/ls1021a-tsn.dts
+++ b/arch/arm/boot/dts/ls1021a-tsn.dts
@@ -129,6 +129,10 @@
 	status = "ok";
 };
 
+&esdhc{
+	status = "okay";
+};
+
 &i2c0 {
 	status = "okay";
 


### PR DESCRIPTION
* This allows the LS1021A-TSN board to probe and boot from the microSD card with the new 4.14 kernel

Signed-off-by: Vladimir Oltean <vladimir.oltean@nxp.com>